### PR TITLE
Adopt DispatchWorkItem for scheduling tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode11.2
+osx_image: xcode11.3
 if: tag is blank
 
 cache:

--- a/DangerFile
+++ b/DangerFile
@@ -28,8 +28,10 @@ warn 'Big PR, try to keep changes smaller if you can 😜' if git.lines_of_code 
 # end
 
 # SWIFTLINT
-swiftlint.lint_all_files = true
-swiftlint.lint_files fail_on_error: true
+swiftlint.config_file = '.swiftlint.yml'
+swiftlint.max_num_violations = 20
+swiftlint.lint_files
+swiftlint.directory = 'Sources'
 
 # TEST EVOLUTION CHECK:
 if has_code_changes

--- a/Mini-Swift.podspec
+++ b/Mini-Swift.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.frameworks = 'Foundation'
 
   s.dependency('RxSwift', '~> 5')
-  s.dependency('SwiftNIOConcurrencyHelpers', '~> 2.0.0')
+  s.dependency('SwiftNIOConcurrencyHelpers', '~> 2.11.0')
 
   s.default_subspec = 'Core'
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "32760eae40e6b7cb81d4d543bb0a9f548356d9a2",
-          "version": "2.7.1"
+          "revision": "f6487a11d80bfb9a0a0a752b7442847c7e3a8253",
+          "version": "2.12.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -81,9 +81,10 @@ let package = Package(
             "pre-push": "swift test",
             "pre-commit": [
                 "swift test",
+                "swift run swiftlint autocorrect --path Sources/",
+                "swift run swiftlint autocorrect --path Tests/",
                 "swift test --generate-linuxmain",
                 "swift run swiftformat .",
-                "swift run swiftlint autocorrect --path Sources/",
                 "git add .",
             ],
         ],

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", .exact("2.7.1")),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.7.1")),
         // Development
         .package(url: "https://github.com/Quick/Nimble.git", .exact("8.0.2")), // dev
         .package(url: "https://github.com/minuscorp/ModuleInterface", from: "0.0.1"), // dev
@@ -46,7 +46,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Mini",
-            dependencies: ["RxSwift", "NIOConcurrencyHelpers"]
+            dependencies: ["RxSwift", "NIOConcurrencyHelpers", "NIO"]
         ),
         .target(
             name: "LoggingService",

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ task(:setup) do
 end
 
 task(:build) do
-  sh('swift build')
+  sh('swift build --disable-sandbox -c release')
 end
 
 task(:test) do

--- a/Sources/Mini/ActionReducer.swift
+++ b/Sources/Mini/ActionReducer.swift
@@ -14,14 +14,14 @@
  limitations under the License.
  */
 
+import Dispatch
 import Foundation
-import RxSwift
 
 /**
  The `Reducer` defines the behavior to be executed when a certain
  `Action` object is received.
  */
-public class Reducer<A: Action>: Disposable {
+public class Reducer<A: Action>: Cancelable {
     /// The `Action` type which the `Reducer` listens to.
     public let action: A.Type
     /// The `Dispatcher` object that sends the `Action` objects.
@@ -29,7 +29,7 @@ public class Reducer<A: Action>: Disposable {
     /// The behavior to be executed when the `Dispatcher` sends a certain `Action`
     public let reducer: (A) -> Void
 
-    private var disposable: Disposable!
+    private var work: WorkItem?
 
     /**
      Initializes a new `Reducer` object.
@@ -42,18 +42,16 @@ public class Reducer<A: Action>: Disposable {
         self.action = action
         self.dispatcher = dispatcher
         self.reducer = reducer
-        disposable = build()
+        work = build()
     }
 
-    private func build() -> Disposable {
-        let disposable = dispatcher.subscribe(tag: action.tag) {
+    private func build() -> WorkItem {
+        dispatcher.subscribe(tag: action.tag) {
             self.reducer($0)
         }
-        return disposable
     }
 
-    /// Dispose resource.
-    public func dispose() {
-        disposable.dispose()
+    public func cancel() {
+        work?.cancel()
     }
 }

--- a/Sources/Mini/ReducerGroup.swift
+++ b/Sources/Mini/ReducerGroup.swift
@@ -17,19 +17,27 @@
 import Foundation
 import RxSwift
 
-public protocol Group: Disposable {
-    var disposeBag: CompositeDisposable { get }
+public typealias CancelableBag = [Cancelable]
+
+public protocol Group: Cancelable {
+    var cancelableBag: [Cancelable] { get }
 }
 
 public class ReducerGroup: Group {
-    public let disposeBag = CompositeDisposable()
+    public var cancelableBag: [Cancelable] = []
 
-    public init(_ builder: Disposable...) {
-        let disposable = builder
-        disposable.forEach { _ = disposeBag.insert($0) }
+    public init(_ builder: Cancelable...) {
+        let cancelable = builder
+        cancelable.forEach { cancelableBag.append($0) }
     }
 
-    public func dispose() {
-        disposeBag.dispose()
+    public func cancel() {
+        cancelableBag.forEach { $0.cancel() }
+    }
+}
+
+public extension Cancelable {
+    func cancelled(by bag: inout CancelableBag) {
+        bag.append(self)
     }
 }

--- a/Tests/MiniSwiftTests/ReducerTests.swift
+++ b/Tests/MiniSwiftTests/ReducerTests.swift
@@ -5,12 +5,13 @@ import XCTest
 
 final class ReducerTests: XCTestCase {
     func test_dispatcher_triggers_action_in_reducer_group_reducer() {
+        var cancelableBag = CancelableBag()
         let dBag = DisposeBag()
         let dispatcher = Dispatcher()
         let store = Store<TestState, TestStoreController>(TestState(), dispatcher: dispatcher, storeController: TestStoreController(dispatcher: dispatcher))
         store
             .reducerGroup
-            .disposed(by: dBag)
+            .cancelled(by: &cancelableBag)
         XCTAssertTrue(store.state.counter.isIdle)
         var counter: Int = 0
         store
@@ -40,6 +41,7 @@ final class ReducerTests: XCTestCase {
 
     func test_subscribe_to_store_receive_actions() {
         let dBag = DisposeBag()
+        var cancelableBag = CancelableBag()
         let dispatcher = Dispatcher()
         let store = Store<TestState, TestStoreController>(TestState(), dispatcher: dispatcher, storeController: TestStoreController(dispatcher: dispatcher))
         XCTAssertTrue(store.state.counter.isIdle)
@@ -53,7 +55,7 @@ final class ReducerTests: XCTestCase {
             .disposed(by: dBag)
         store
             .reducerGroup
-            .disposed(by: dBag)
+            .cancelled(by: &cancelableBag)
         dispatcher.dispatch(
             SetCounterAction(counter: 2),
             mode: .sync
@@ -63,6 +65,7 @@ final class ReducerTests: XCTestCase {
 
     func test_subscribe_to_store_receive_multiple_actions() {
         let dBag = DisposeBag()
+        var cancelableBag = CancelableBag()
         let dispatcher = Dispatcher()
         let store = Store<TestState, TestStoreController>(TestState(), dispatcher: dispatcher, storeController: TestStoreController(dispatcher: dispatcher))
         XCTAssertTrue(store.state.counter.isIdle)
@@ -76,7 +79,7 @@ final class ReducerTests: XCTestCase {
             .disposed(by: dBag)
         store
             .reducerGroup
-            .disposed(by: dBag)
+            .cancelled(by: &cancelableBag)
         dispatcher.dispatch(
             SetCounterAction(counter: 2),
             mode: .sync
@@ -91,6 +94,7 @@ final class ReducerTests: XCTestCase {
 
     func test_reset_state() {
         let dBag = DisposeBag()
+        var cancelableBag = CancelableBag()
         let dispatcher = Dispatcher()
         let initialState = TestState()
         let store = Store<TestState, TestStoreController>(initialState, dispatcher: dispatcher, storeController: TestStoreController(dispatcher: dispatcher))
@@ -105,7 +109,7 @@ final class ReducerTests: XCTestCase {
             .disposed(by: dBag)
         store
             .reducerGroup
-            .disposed(by: dBag)
+            .cancelled(by: &cancelableBag)
         dispatcher.dispatch(
             SetCounterAction(counter: 3),
             mode: .sync
@@ -117,6 +121,7 @@ final class ReducerTests: XCTestCase {
 
     func test_state_received_in_store() throws {
         let dBag = DisposeBag()
+        var cancelableBag = CancelableBag()
         let dispatcher = Dispatcher()
         let initialState = TestState()
         let store = Store<TestState, TestStoreController>(initialState, dispatcher: dispatcher, storeController: TestStoreController(dispatcher: dispatcher))
@@ -131,7 +136,7 @@ final class ReducerTests: XCTestCase {
             .disposed(by: dBag)
         store
             .reducerGroup
-            .disposed(by: dBag)
+            .cancelled(by: &cancelableBag)
         dispatcher.dispatch(
             SetCounterAction(counter: 3),
             mode: .sync

--- a/Tests/MiniSwiftTests/RxTests/ObservableTypeTests.swift
+++ b/Tests/MiniSwiftTests/RxTests/ObservableTypeTests.swift
@@ -61,11 +61,12 @@ final class ObservableTypeTests: XCTestCase {
 
     func test_dispatch_action_from_store() throws {
         let dispatcher = Dispatcher()
+        var cancelableBag = CancelableBag()
         let store = Store<TestState, TestStoreController>(TestState(), dispatcher: dispatcher, storeController: TestStoreController(dispatcher: dispatcher))
 
         store
             .reducerGroup
-            .disposed(by: disposeBag)
+            .cancelled(by: &cancelableBag)
 
         guard let state = try Observable<Store<TestState, TestStoreController>>
             .dispatch(using: dispatcher,
@@ -84,11 +85,12 @@ final class ObservableTypeTests: XCTestCase {
 
     func test_dispatch_hashable_action_from_store() throws {
         let dispatcher = Dispatcher()
+        var cancelableBag = CancelableBag()
         let store = Store<TestState, TestStoreController>(TestState(), dispatcher: dispatcher, storeController: TestStoreController(dispatcher: dispatcher))
 
         store
             .reducerGroup
-            .disposed(by: disposeBag)
+            .cancelled(by: &cancelableBag)
 
         guard let state = try Observable<Store<TestState, TestStoreController>>
             .dispatch(using: dispatcher,


### PR DESCRIPTION
Adopt `DispatchWorkItem` for better Foundation, Dispatch and NIO interoperability.

#### Breaking changes:
- `reducerGroup` does not depend on `RxSwift` anymore, so for managing subscriptions we use a `Combine`-like approach, where the `Cancelable`s are just added to a `[Cancelable]` that can be cleaned up `removeAll()` or just released on `deinit`
